### PR TITLE
[feat] 동행 게시판 참가자 리스트 entity 추가

### DIFF
--- a/src/main/java/com/crude/travelcrew/domain/board/dto/MemberListReq.java
+++ b/src/main/java/com/crude/travelcrew/domain/board/dto/MemberListReq.java
@@ -1,0 +1,13 @@
+package com.crude.travelcrew.domain.board.dto;
+
+public class MemberListReq {
+	private Long memberId;
+
+	public Long getMemberId() {
+		return memberId;
+	}
+
+	public void setMemberId(Long memberId) {
+		this.memberId = memberId;
+	}
+}

--- a/src/main/java/com/crude/travelcrew/domain/board/dto/MemberListRes.java
+++ b/src/main/java/com/crude/travelcrew/domain/board/dto/MemberListRes.java
@@ -1,0 +1,22 @@
+package com.crude.travelcrew.domain.board.dto;
+
+public class MemberListRes {
+	private Long memberId;
+	private String nickname;
+
+	public Long getMemberId() {
+		return memberId;
+	}
+
+	public void setMemberId(Long memberId) {
+		this.memberId = memberId;
+	}
+
+	public String getNickname() {
+		return nickname;
+	}
+
+	public void setNickname(String nickname) {
+		this.nickname = nickname;
+	}
+}

--- a/src/main/java/com/crude/travelcrew/domain/board/entity/Posts.java
+++ b/src/main/java/com/crude/travelcrew/domain/board/entity/Posts.java
@@ -2,7 +2,10 @@ package com.crude.travelcrew.domain.board.entity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -80,6 +83,11 @@ public class Posts extends BaseTime {
 
 	@Column(nullable = false)
 	private String crewContent;
+
+	// 동행 참가자 명단
+	@OneToMany(mappedBy = "posts", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Member> memberList = new ArrayList<>();
+
 
 
 	public Posts(PostsReq postsReq) {

--- a/src/main/java/com/crude/travelcrew/domain/board/entity/Posts.java
+++ b/src/main/java/com/crude/travelcrew/domain/board/entity/Posts.java
@@ -30,11 +30,13 @@ import com.crude.travelcrew.global.entity.BaseTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @Entity(name = "crew_post")
+@ToString
 public class Posts extends BaseTime {
 
 	@Id
@@ -55,6 +57,7 @@ public class Posts extends BaseTime {
 	@Enumerated(EnumType.STRING)
 	private CrewStatus crewStatus;
 
+	// 참가인원수
 	@Column
 	private Integer maxCrew;
 
@@ -87,6 +90,18 @@ public class Posts extends BaseTime {
 	// 동행 참가자 명단
 	@OneToMany(mappedBy = "posts", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Member> memberList = new ArrayList<>();
+
+	// 참가자 추가
+	public void addMemberList(Member participant) {
+		memberList.add(participant);
+		participant.setPosts(this);
+	}
+
+	// 참가자 제거
+	public void removeMemberList(Member participant) {
+		memberList.remove(participant);
+		participant.setPosts(null);
+	}
 
 
 

--- a/src/main/java/com/crude/travelcrew/domain/board/service/MemberListService.java
+++ b/src/main/java/com/crude/travelcrew/domain/board/service/MemberListService.java
@@ -1,0 +1,40 @@
+package com.crude.travelcrew.domain.board.service;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.crude.travelcrew.domain.board.dto.MemberListReq;
+import com.crude.travelcrew.domain.board.entity.Posts;
+import com.crude.travelcrew.domain.board.repository.PostsRepository;
+import com.crude.travelcrew.domain.member.entity.Member;
+import com.crude.travelcrew.domain.member.repository.MemberRepository;
+
+@Service
+public class MemberListService {
+	@Autowired
+	private PostsRepository postsRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+
+	// 참가자 추가
+	public void addMemberList(Long postId, MemberListReq memberListReq) {
+		Posts post = postsRepository.findById(postId).orElseThrow(() -> new EntityNotFoundException("게시물을 찾을 수 없음"));
+		Member member = memberRepository.findById(memberListReq.getMemberId()).orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없음"));
+
+		post.addMemberList(member);
+
+		postsRepository.save(post);
+	}
+
+	// 멤버 리스트 제거
+	public void removeMemberList(Long postId, Long memberId) {
+		Posts post = postsRepository.findById(postId).orElseThrow(() -> new EntityNotFoundException("게시물을 찾을 수 없음"));
+		Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없음"));
+
+		post.removeMemberList(member);
+
+		postsRepository.save(post);
+	}
+}

--- a/src/main/java/com/crude/travelcrew/domain/member/entity/Member.java
+++ b/src/main/java/com/crude/travelcrew/domain/member/entity/Member.java
@@ -8,9 +8,12 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+import com.crude.travelcrew.domain.board.entity.Posts;
 import com.crude.travelcrew.domain.member.constants.MemberRole;
 import com.crude.travelcrew.domain.member.constants.MemberStatus;
 import com.crude.travelcrew.domain.member.constants.ProviderType;
@@ -62,5 +65,10 @@ public class Member extends BaseTime {
 		this.password = signUpReq.getPassword();
 		this.nickname = signUpReq.getNickname();
 	}
+
+	// 동행 게시판 참가자
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "crew_id", updatable = false)
+	private Posts posts;
 
 }


### PR DESCRIPTION
## 📌 작업 이슈
closed #27  

## 📄 작업 내용
- 동행 게시판 참가자 DB 저장(memberList) , 추가, 삭제
 - MemberList, addMemberList, deleteMemberList Posts class에 entity 추가
 - MemberListRequestDto, MemberListResponseDto 파일 추가
 - MemberList 추가, 제거 Service 등록

## 🌟 요청 사항
Posts entity 클래스에 참가자 리스트, 추가, 삭제 entity 추가했습니다. 
member Entity 클래스에 'Posts' private 필드를 추가했습니다. 

참가자 추가 및 삭제는 controller만 작성하면 사용 가능할 것 같습니다. 
controller는 필요에 따라 사용 가능하도록 아직 작성하지 않았습니다. 
