### PR TITLE
[feat] 이메일 인증 기능 구현

### DIFF
--- a/src/main/java/com/crude/travelcrew/domain/email/controller/EmailController.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/controller/EmailController.java
@@ -1,0 +1,31 @@
+package com.crude.travelcrew.domain.email.controller;
+
+import com.crude.travelcrew.domain.email.model.EmailAuthReq;
+import com.crude.travelcrew.domain.email.model.EmailMessage;
+import com.crude.travelcrew.domain.email.service.EmailSenderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+@Slf4j
+public class EmailController {
+
+    private final EmailSenderService emailSenderService;
+
+    // 이메일 인증번호 발송
+    @PostMapping("/email/send")
+    public ResponseEntity<?> sendEmailAuth(@RequestBody EmailMessage emailMessage) {
+        String authCode = UUID.randomUUID().toString();
+        emailSenderService.sendEmail(emailMessage, authCode);
+        return ResponseEntity.ok("이메일 전송됨");
+    }
+}

--- a/src/main/java/com/crude/travelcrew/domain/email/controller/EmailController.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/controller/EmailController.java
@@ -1,7 +1,7 @@
 package com.crude.travelcrew.domain.email.controller;
 
-import com.crude.travelcrew.domain.email.model.EmailAuthReq;
-import com.crude.travelcrew.domain.email.model.EmailMessage;
+import com.crude.travelcrew.domain.email.model.EmailSendReq;
+import com.crude.travelcrew.domain.email.model.EmailVerifyReq;
 import com.crude.travelcrew.domain.email.service.EmailSenderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,8 +10,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/member")
@@ -23,9 +21,17 @@ public class EmailController {
 
     // 이메일 인증번호 발송
     @PostMapping("/email/send")
-    public ResponseEntity<?> sendEmailAuth(@RequestBody EmailMessage emailMessage) {
-        String authCode = UUID.randomUUID().toString();
-        emailSenderService.sendEmail(emailMessage, authCode);
-        return ResponseEntity.ok("이메일 전송됨");
+    public ResponseEntity<?> sendEmail(@RequestBody EmailSendReq emailSendReq) {
+        this.emailSenderService.sendEmail(emailSendReq);
+        return ResponseEntity.ok("이메일 전송 및 Redis에 저장");
     }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<?> verifyEmail(@RequestBody EmailVerifyReq emailVerifyReq) {
+        boolean result = emailSenderService.verifyEmail(emailVerifyReq);
+        if (result) {
+            return ResponseEntity.ok("인증성공");
+        } else return ResponseEntity.badRequest().body("인증실패");
+    }
+
 }

--- a/src/main/java/com/crude/travelcrew/domain/email/model/EmailMessage.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/model/EmailMessage.java
@@ -1,0 +1,16 @@
+package com.crude.travelcrew.domain.email.model;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailMessage {
+
+    private String to;
+    private String subject;
+    private String message;
+}

--- a/src/main/java/com/crude/travelcrew/domain/email/model/EmailSendReq.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/model/EmailSendReq.java
@@ -1,0 +1,10 @@
+package com.crude.travelcrew.domain.email.model;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class EmailSendReq {
+    private String email;
+}

--- a/src/main/java/com/crude/travelcrew/domain/email/model/EmailVerifyReq.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/model/EmailVerifyReq.java
@@ -1,0 +1,11 @@
+package com.crude.travelcrew.domain.email.model;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class EmailVerifyReq {
+    private String email;
+    private String authCode;
+}

--- a/src/main/java/com/crude/travelcrew/domain/email/service/EmailSenderService.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/service/EmailSenderService.java
@@ -1,9 +1,15 @@
 package com.crude.travelcrew.domain.email.service;
 
-import com.crude.travelcrew.domain.email.model.EmailMessage;
+import com.crude.travelcrew.domain.email.model.EmailSendReq;
+import com.crude.travelcrew.domain.email.model.EmailVerifyReq;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface EmailSenderService {
     // 이메일 전송
-    boolean sendEmail(EmailMessage emailMessage, String authCode);
+    void sendEmail(EmailSendReq emailSendReq);
+
+    // 인증키 검증
+    @Transactional
+    Boolean verifyEmail(EmailVerifyReq emailVerifyReq);
 
 }

--- a/src/main/java/com/crude/travelcrew/domain/email/service/EmailSenderService.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/service/EmailSenderService.java
@@ -1,0 +1,9 @@
+package com.crude.travelcrew.domain.email.service;
+
+import com.crude.travelcrew.domain.email.model.EmailMessage;
+
+public interface EmailSenderService {
+    // 이메일 전송
+    boolean sendEmail(EmailMessage emailMessage, String authCode);
+
+}

--- a/src/main/java/com/crude/travelcrew/domain/email/service/EmailSenderServiceImpl.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/service/EmailSenderServiceImpl.java
@@ -1,0 +1,38 @@
+package com.crude.travelcrew.domain.email.service;
+
+import com.crude.travelcrew.domain.email.model.EmailMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailSenderServiceImpl implements EmailSenderService {
+
+    public static final String subject = "[동행크루] 이메일 인증 코드 입니다.";
+
+    @Value("${spring.mail.username}")
+    private String from;
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public boolean sendEmail(EmailMessage emailMessage, String authCode) {
+        try {
+            SimpleMailMessage smm = new SimpleMailMessage();
+            smm.setFrom(from);
+            smm.setTo(emailMessage.getTo());
+            smm.setSubject(subject);
+            smm.setText(emailMessage.getMessage() + authCode);
+            this.javaMailSender.send(smm);
+        } catch (Exception e) {
+            log.error("can not send email. [" + e.getMessage() + "]");
+            return false;
+        }
+        log.info("email send success");
+        return true;
+    }
+}

--- a/src/main/java/com/crude/travelcrew/domain/email/service/EmailSenderServiceImpl.java
+++ b/src/main/java/com/crude/travelcrew/domain/email/service/EmailSenderServiceImpl.java
@@ -1,38 +1,62 @@
 package com.crude.travelcrew.domain.email.service;
 
-import com.crude.travelcrew.domain.email.model.EmailMessage;
+import com.crude.travelcrew.domain.email.model.EmailSendReq;
+import com.crude.travelcrew.domain.email.model.EmailVerifyReq;
+import com.crude.travelcrew.global.redis.RedisKey;
+import com.crude.travelcrew.global.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@EnableAsync
 public class EmailSenderServiceImpl implements EmailSenderService {
 
     public static final String subject = "[동행크루] 이메일 인증 코드 입니다.";
-
+    public static final String text = "동행크루 회원 가입 인증코드 : ";
+    public static final String authCode = UUID.randomUUID().toString();
     @Value("${spring.mail.username}")
     private String from;
+
     private final JavaMailSender javaMailSender;
+    private final RedisService redisService;
 
     @Override
-    public boolean sendEmail(EmailMessage emailMessage, String authCode) {
+    @Async
+    public void sendEmail(EmailSendReq emailSendReq) {
         try {
             SimpleMailMessage smm = new SimpleMailMessage();
             smm.setFrom(from);
-            smm.setTo(emailMessage.getTo());
+            smm.setTo(emailSendReq.getEmail());
             smm.setSubject(subject);
-            smm.setText(emailMessage.getMessage() + authCode);
+            smm.setText(text + authCode);
             this.javaMailSender.send(smm);
+            redisService.setDataWithExpiration(RedisKey.EAUTH.getKey() + emailSendReq.getEmail(), authCode, 60 * 5L);
+            log.info("email send success, authCode : " + redisService.getData(RedisKey.EAUTH.getKey() + emailSendReq.getEmail()));
         } catch (Exception e) {
             log.error("can not send email. [" + e.getMessage() + "]");
-            return false;
         }
-        log.info("email send success");
-        return true;
+    }
+
+    @Transactional
+    @Override
+    public Boolean verifyEmail(EmailVerifyReq emailVerifyReq) {
+        String storedCode = redisService.getData(RedisKey.EAUTH.getKey() + emailVerifyReq.getEmail());
+            log.info("redis stored key : " + storedCode);
+            log.info("input authCode : " + authCode);
+        if (storedCode != null && storedCode.equals(authCode)) {
+            redisService.deleteData(RedisKey.EAUTH.getKey() + emailVerifyReq.getEmail());
+            return true;
+        } else return false;
     }
 }


### PR DESCRIPTION
## 📌 작업 이슈
closed #78

## 📄 작업 내용
인증 이메일을 보내고 redis에 저장.
사용자가 인증 코드를 입력, 전송 하면 redis에 저장된 값과 비교후 인증 여부를 결정
인증이 완료되면 redis에서 해당 인증 코드를 삭제.

## 🌟 요청 사항
- 이메일 인증 요청은 이메일정보만 전송합니다.
   /api/member/email/send
{
    "email" : "email@gmail.com"
}
- 받은 이메일로 인증확인하려면 이메일과 authCode를 보냅니다.
   /api/member/email/verify
{
    "email" : "email@gmail.com",
    "authCode" : "3ce1c828-604c-46ea-91a7-7c370937d3bc"
}

redisconfig는 제외하고 commit 했습니다.